### PR TITLE
Fix birthdate selection bug on IOS - closes #4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackarest-ts",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackarest-ts",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@clerk/clerk-react": "^5.31.1",
         "@clerk/localizations": "^3.15.1",

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -31,6 +31,7 @@ export default function DatePicker({
         ...options,
         maxDate,
         minDate,
+        disableMobile: true,
         onChange: (selectedDates, dateStr) => {
           onChange?.(selectedDates, dateStr);
         },
@@ -51,7 +52,7 @@ export default function DatePicker({
       ref={inputRef}
       value={value ?? ""}
       readOnly
-      className="bg-primary text-white text-sm placeholder:text-muted-foreground px-4 py-3 rounded-lg border border-transparent focus:border-[#00d8ff] outline-none transition-all duration-200"
+      className="[appearance:none] bg-primary text-white text-sm placeholder:text-muted-foreground px-4 py-3 rounded-lg border border-transparent focus:border-[#00d8ff] outline-none transition-all duration-200"
       placeholder="Selectează o dată"
     />
   );


### PR DESCRIPTION
Fix to problem #4 by removing default IOS datepicker modal and switching to the custom version instead. Also fixes the width of the datepicker on mobile devices.